### PR TITLE
Use GOLANG 1.6.2 consistently

### DIFF
--- a/backup/src/snap_stub/Dockerfile
+++ b/backup/src/snap_stub/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6.0
+FROM golang:1.6.2
 
 RUN apt-get install -y git
 

--- a/backup/src/workload/Dockerfile
+++ b/backup/src/workload/Dockerfile
@@ -3,9 +3,9 @@ FROM ubuntu
 RUN apt-get update
 RUN apt-get install -y git stress curl
 
-ENV GOLANG_VERSION 1.6.1
+ENV GOLANG_VERSION 1.6.2
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 6d894da8b4ad3f7f6c295db0d73ccc3646bce630e1c43e662a0120681d47e988
+ENV GOLANG_DOWNLOAD_SHA256 e40c36ae71756198478624ed1bb4ce17597b3c19d243f3f0899bb5740d56212a
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/src/heapster/Dockerfile
+++ b/src/heapster/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6.0
+FROM golang:1.6.2
 
 RUN apt-get install -y git
 RUN git clone https://github.com/andrzej-k/heapster.git /go/src/k8s.io/heapster

--- a/src/snap/Dockerfile
+++ b/src/snap/Dockerfile
@@ -13,9 +13,9 @@ RUN curl -fSL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-$DOCKER_VERSI
 	&& chmod +x /usr/local/bin/docker
 
 # get golang for building snap and plugins
-ENV GOLANG_VERSION 1.6.1
+ENV GOLANG_VERSION 1.6.2
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 6d894da8b4ad3f7f6c295db0d73ccc3646bce630e1c43e662a0120681d47e988
+ENV GOLANG_DOWNLOAD_SHA256 e40c36ae71756198478624ed1bb4ce17597b3c19d243f3f0899bb5740d56212a
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \


### PR DESCRIPTION
This helps reduce number of docker images needed in local registry.